### PR TITLE
Use `getBulkyItemStorage` instead of `getBulkyGoodsStorage`

### DIFF
--- a/docs/notification-center/developers/_index.en.md
+++ b/docs/notification-center/developers/_index.en.md
@@ -175,7 +175,7 @@ Let's look at how the Core uses this to pass on file uploads from the form gener
 <?php
 
 foreach ($files as $k => $file) {
-    $voucher = $this->notificationCenter->getBulkyGoodsStorage()->store(
+    $voucher = $this->notificationCenter->getBulkyItemStorage()->store(
         FileItem::fromPath($file['tmp_name'], $file['name'], $file['type'], $file['size'])
     );
 
@@ -200,7 +200,7 @@ look for example like this:
 ```php
 <?php
 
-$item = $this->getNotificationCenter()->getBulkyGoodsStorage()->retrieve($voucher);
+$item = $this->getNotificationCenter()->getBulkyItemStorage()->retrieve($voucher);
 
 if ($item instanceof FileItem) {
     $email->attach(


### PR DESCRIPTION
### Description

Just updating as the method has been marked deprecated :)
https://github.com/terminal42/contao-notification_center/blob/fb2db967629116813582b897440143d72c428614/src/NotificationCenter.php#L63