### PR TITLE
Fix the relearn theme update

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -18,7 +18,7 @@ jobs:
             - name: Setup Hugo
               uses: peaceiris/actions-hugo@v2
               with:
-                  hugo-version: '0.152.2'
+                  hugo-version: '0.153.4'
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/docs/changelanguage/_index.en.md
+++ b/docs/changelanguage/_index.en.md
@@ -1,9 +1,7 @@
 ---
-title: "ChangeLanguage"
+title: "ChangeLanguage v3"
 type: home
 ---
-
-# ChangeLanguage v3
 
 *ChangeLanguage* is an extension for the [Contao CMS][1] (version 3.5 and 4.x)
 which allows visitors to switch between different languages of your website.

--- a/docs/notification-center-pro/_index.de.md
+++ b/docs/notification-center-pro/_index.de.md
@@ -3,8 +3,6 @@ title: "Notification Center Pro"
 type: home
 ---
 
-# Notification Center Pro
-
 Notification Center Pro ist eine kommerzielle Erweiterung für unser [kostenloses und sehr beliebtes Notification Center][NC].
 
 Zusätzlich zur kostenlosen Version erweitert Notification Center Pro dein Notification Center-Erlebnis um die

--- a/docs/notification-center-pro/_index.en.md
+++ b/docs/notification-center-pro/_index.en.md
@@ -3,8 +3,6 @@ title: "Notification Center Pro"
 type: home
 ---
 
-# Notification Center Pro
-
 Notification Center Pro is a commercial extension to our [free and very popular Notification Center][NC]. 
 
 On top of using the free version, Notification Center Pro will enhance your Notification Center experience with the 

--- a/docs/notification-center/_index.en.md
+++ b/docs/notification-center/_index.en.md
@@ -3,8 +3,6 @@ title: "Notification Center"
 type: home
 ---
 
-# Notification Center
-
 
 The Notification Center is an extension for the [Contao CMS][1] which
 provides a central and flexible way for Contao users to configure notifications

--- a/docs/payment-pfc/_index.de.md
+++ b/docs/payment-pfc/_index.de.md
@@ -3,8 +3,6 @@ title: "Postfinance Checkout für Isotope eCommerce"
 type: home
 ---
 
-# PostFinance Checkout
-
 [PostFinance Checkout][website] ist eine Online-Zahlungslösung der Schweizerischen PostFinance.
 
 > Mit PostFinance Checkout erhalten Sie eine flexible und funktionsstarke Payment Service Providing Lösung für Ihren

--- a/docs/payment-stripe/_index.de.md
+++ b/docs/payment-stripe/_index.de.md
@@ -3,8 +3,6 @@ title: "Stripe Zahlungen für Isotope eCommerce"
 type: home
 ---
 
-# Stripe Zahlungen für Isotope eCommerce
-
 Mit dieser Erweiterung kannst du den Zahlungsanbieter [Stripe](https://www.stripe.com)
 in deinem Isotope eCommerce Shop verwenden.
 

--- a/docs/payment-stripe/_index.en.md
+++ b/docs/payment-stripe/_index.en.md
@@ -3,8 +3,6 @@ title: "Stripe payments for Isotope eCommerce"
 type: home
 ---
 
-# Stripe payments for Isotope eCommerce
-
 With this extension you can use the payment provider [Stripe](https://www.stripe.com)
 in your Isotope eCommerce Shop.
 

--- a/docs/shipping-plc/_index.de.md
+++ b/docs/shipping-plc/_index.de.md
@@ -3,8 +3,6 @@ title: "Post-Labelcenter"
 type: home
 ---
 
-# Post-Labelcenter 
-
 Mit Hilfe der Versandsoftware [**Post-Labelcenter**][PLC] erstellst du rasch und gemäß den Anforderungen der 
 Österreichischen Post deine Paketaufkleber, Sendungslisten und die dazu notwendigen Avisodaten für eine 
 optimale logistische Abwicklung.

--- a/page/assets/css/theme-terminal42.css
+++ b/page/assets/css/theme-terminal42.css
@@ -166,7 +166,7 @@ b, strong, label, th {
 }
 
 #R-header-wrapper {
-    border-bottom: 4px solid var(--MENU-HEADER-BORDER-color);
+    border-bottom: 4px solid var(--MENU-HEADER-BORDER-color) !important;
 }
 
 #R-homelinks {
@@ -212,8 +212,9 @@ b, strong, label, th {
 }
 
 /* Logo */
-#R-header #logo {
+#R-header-wrapper #logo {
     display: block;
+    margin: 1rem 0;
 }
 
 #logo svg {
@@ -227,6 +228,9 @@ b, strong, label, th {
     display: block;
     margin-top: 4px;
     text-align: center;
+}
+
+#R-sidebar > #R-header-wrapper :is(a, span) {
     color: white;
 }
 


### PR DESCRIPTION
### Description

The update mentioned in https://github.com/terminal42/extensions-docs/pull/11#issuecomment-3638660077 did not properly update the docs. You might have realized the logo color, paddings + double headlines:

<img width="1086" height="735" alt="grafik" src="https://github.com/user-attachments/assets/d928f6f7-af38-44f0-a383-e811b183a962" />

https://extensions.terminal42.ch/docs/notification-center-pro/de/

This adjusts the changes, also updates the hugo-version to the latest.